### PR TITLE
SystemProperties Seam for Testing

### DIFF
--- a/src/Lucene.Net.TestFramework/Support/LuceneTestFrameworkInitializer.cs
+++ b/src/Lucene.Net.TestFramework/Support/LuceneTestFrameworkInitializer.cs
@@ -1,0 +1,61 @@
+﻿using Lucene.Net.Codecs;
+using Lucene.Net.Configuration;
+using NUnit.Framework;
+using System;
+
+[SetUpFixture]
+public class LuceneTestFrameworkInitializer
+{
+    // LUCENENET specific constants to scan the test framework for codecs/docvaluesformats/postingsformats only once
+    public static ICodecFactory CodecFactory { get; set; } = new TestCodecFactory();
+    public static IDocValuesFormatFactory DocValuesFormatFactory { get; set; } = new TestDocValuesFormatFactory();
+    public static IPostingsFormatFactory PostingsFormatFactory { get; set; } = new TestPostingsFormatFactory();
+
+    [CLSCompliant(false)]
+    public static IConfigurationRootFactory ConfigurationFactory { get; set; } = new TestConfigurationRootFactory();
+
+    [OneTimeSetUp]
+    public void OneTimeSetUpBeforeTests()
+    {
+        TestFrameworkSetUp();
+
+        try
+        {
+            // Setup the factories
+            ConfigurationSettings.SetConfigurationRootFactory(ConfigurationFactory);
+            Codec.SetCodecFactory(CodecFactory);
+            DocValuesFormat.SetDocValuesFormatFactory(DocValuesFormatFactory);
+            PostingsFormat.SetPostingsFormatFactory(PostingsFormatFactory);
+        }
+        catch (Exception ex)
+        {
+            // Write the stack trace so we have something to go on if an error occurs here.
+            throw new Exception($"An exception occurred during OneTimeSetUpBeforeTests:\n{ex.ToString()}", ex);
+        }
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDownAfterTests()
+    {
+        try
+        {
+            TestFrameworkTearDown();
+        }
+        catch (Exception ex)
+        {
+            // Write the stack trace so we have something to go on if an error occurs here.
+            throw new Exception($"An exception occurred during OneTimeTearDownAfterTests:\n{ex.ToString()}", ex);
+        }
+    }
+
+    public virtual void TestFrameworkSetUp()
+    {
+        // Runs only once per test framework run before all tests
+    }
+
+
+    public virtual void TestFrameworkTearDown()
+    {
+        // Runs only once per test framework run after all tests
+    }
+}

--- a/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
+++ b/src/Lucene.Net.TestFramework/Util/LuceneTestCase.cs
@@ -691,14 +691,6 @@ namespace Lucene.Net.Util
                 */
         }
 
-        // LUCENENET specific constants to scan the test framework for codecs/docvaluesformats/postingsformats only once
-        public static ICodecFactory CodecFactory { get; set; } = new TestCodecFactory();
-        public static IDocValuesFormatFactory DocValuesFormatFactory { get; set; } = new TestDocValuesFormatFactory();
-        public static IPostingsFormatFactory PostingsFormatFactory { get; set; } = new TestPostingsFormatFactory();
-
-        [CLSCompliant(false)]
-        public static IConfigurationRootFactory ConfigurationFactory { get; set; } = new TestConfigurationRootFactory();
-
 #if TESTFRAMEWORK_MSTEST
         private static readonly IList<string> initalizationLock = new List<string>();
         private static string _testClassName = string.Empty;
@@ -773,12 +765,6 @@ namespace Lucene.Net.Util
         {
             try
             {
-                // Setup the factories
-                ConfigurationSettings.SetConfigurationRootFactory(ConfigurationFactory);
-                Codec.SetCodecFactory(CodecFactory);
-                DocValuesFormat.SetDocValuesFormatFactory(DocValuesFormatFactory);
-                PostingsFormat.SetPostingsFormatFactory(PostingsFormatFactory);
-
                 ClassEnvRule.Before(this);
             }
             catch (Exception ex)

--- a/src/Lucene.Net/Support/Configuration/ConfigurationSettings.cs
+++ b/src/Lucene.Net/Support/Configuration/ConfigurationSettings.cs
@@ -40,6 +40,15 @@ namespace Lucene.Net.Configuration
         /// Returns the current configuration
         /// </summary>
         [CLSCompliant(false)]
-        public static IConfigurationRoot CurrentConfiguration => configurationRootFactory.CurrentConfiguration;
+        public static IConfigurationRootFactory GetConfigurationFactory()
+        {
+            return configurationRootFactory;
+        }
+
+        /// <summary>
+        /// Returns the current configuration
+        /// </summary>
+        [CLSCompliant(false)]
+        public static IConfigurationRoot CurrentConfiguration => configurationRootFactory.CreateConfiguration();
     }
 }

--- a/src/Lucene.Net/Support/Util/IProperties.cs
+++ b/src/Lucene.Net/Support/Util/IProperties.cs
@@ -1,7 +1,4 @@
-﻿using Lucene.Net.Configuration;
-using Microsoft.Extensions.Configuration;
-
-namespace Lucene.Net.Util
+﻿namespace Lucene.Net.Util
 {
     /*
      * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -21,29 +18,16 @@ namespace Lucene.Net.Util
      */
 
     /// <summary>
-    /// Reads properties from an <see cref="IProperties"/> instance. The default configuration reads
-    /// the property valies from an <see cref="IConfigurationRoot"/> instance returned by a
-    /// <see cref="IConfigurationRootFactory"/> implementation.
-    /// The <see cref="IConfigurationRootFactory"/> is set using
-    /// <see cref="ConfigurationSettings.SetConfigurationRootFactory(IConfigurationRootFactory)"/>.
-    /// This can be supplied a user implemented <see cref="IConfigurationRootFactory"/> to customize
-    /// the property sources.
+    /// Contract for Java-style properties.
     /// </summary>
-    internal static class SystemProperties
+    internal interface IProperties
     {
-        // Calls ConfigurationSettings.GetConfigurationRootFactory internally to
-        // get the currently set instance of IConfigurationRootFactory
-        private readonly static IProperties properties = new Properties(ConfigurationSettings.GetConfigurationRootFactory().CreateConfiguration);
-
         /// <summary>
         /// Retrieves the value of a property from the current process.
         /// </summary>
         /// <param name="key">The name of the property.</param>
         /// <returns>The property value.</returns>
-        public static string GetProperty(string key)
-        {
-            return properties.GetProperty(key);
-        }
+        string GetProperty(string key);
 
         /// <summary>
         /// Retrieves the value of a property from the current process, 
@@ -54,10 +38,7 @@ namespace Lucene.Net.Util
         /// <param name="defaultValue">The value to use if the property does not exist 
         /// or the caller doesn't have permission to read the value.</param>
         /// <returns>The property value.</returns>
-        public static string GetProperty(string key, string defaultValue)
-        {
-            return properties.GetProperty(key, defaultValue);
-        }
+        string GetProperty(string key, string defaultValue);
 
         /// <summary>
         /// Retrieves the value of a property from the current process
@@ -65,10 +46,7 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="key">The name of the property.</param>
         /// <returns>The property value.</returns>
-        public static bool GetPropertyAsBoolean(string key)
-        {
-            return properties.GetPropertyAsBoolean(key);
-        }
+        bool GetPropertyAsBoolean(string key);
 
         /// <summary>
         /// Retrieves the value of a property from the current process as <see cref="bool"/>, 
@@ -79,10 +57,7 @@ namespace Lucene.Net.Util
         /// <param name="defaultValue">The value to use if the property does not exist,
         /// the caller doesn't have permission to read the value, or the value cannot be cast to <see cref="bool"/>.</param>
         /// <returns>The property value.</returns>
-        public static bool GetPropertyAsBoolean(string key, bool defaultValue)
-        {
-            return properties.GetPropertyAsBoolean(key, defaultValue);
-        }
+        bool GetPropertyAsBoolean(string key, bool defaultValue);
 
         /// <summary>
         /// Retrieves the value of a property from the current process
@@ -90,10 +65,7 @@ namespace Lucene.Net.Util
         /// </summary>
         /// <param name="key">The name of the property.</param>
         /// <returns>The property value.</returns>
-        public static int GetPropertyAsInt32(string key)
-        {
-            return properties.GetPropertyAsInt32(key);
-        }
+        int GetPropertyAsInt32(string key);
 
         /// <summary>
         /// Retrieves the value of a property from the current process as <see cref="int"/>, 
@@ -104,9 +76,6 @@ namespace Lucene.Net.Util
         /// <param name="defaultValue">The value to use if the property does not exist,
         /// the caller doesn't have permission to read the value, or the value cannot be cast to <see cref="int"/>.</param>
         /// <returns>The property value.</returns>
-        public static int GetPropertyAsInt32(string key, int defaultValue)
-        {
-            return properties.GetPropertyAsInt32(key, defaultValue);
-        }
+        int GetPropertyAsInt32(string key, int defaultValue);
     }
 }

--- a/src/Lucene.Net/Support/Util/Properties.cs
+++ b/src/Lucene.Net/Support/Util/Properties.cs
@@ -1,0 +1,154 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+
+namespace Lucene.Net.Util
+{
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one or more
+     * contributor license agreements.  See the NOTICE file distributed with
+     * this work for additional information regarding copyright ownership.
+     * The ASF licenses this file to You under the Apache License, Version 2.0
+     * (the "License"); you may not use this file except in compliance with
+     * the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+
+    /// <summary>
+    /// Implementation of <see cref="IProperties"/> that handles type conversion and default values 
+    /// for Java-style properties.
+    /// <para/>
+    /// Reads properties from an <see cref="IConfigurationRoot" /> instance or
+    /// a <see cref="Func{IConfigurationRoot}"/> that is supplied to the constructor.
+    /// </summary>
+    internal class Properties : IProperties
+    {
+        private readonly Func<IConfiguration> createConfiguration;
+
+        /// <summary>
+        /// Initaializes a new instance of <see cref="Properties"/> with the specified <see cref="IConfiguration"/>.
+        /// </summary>
+        /// <param name="configuration">The <see cref="IConfiguration"/>.</param>
+        public Properties(IConfiguration configuration)
+        {
+            if (configuration == null)
+                throw new ArgumentNullException(nameof(configuration));
+            this.createConfiguration = () => configuration;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="Properties"/> with the specified <see cref="Func{IConfiguration}"/>.
+        /// The delegate method ensures the current instance of <see cref="IConfiguration"/> is used.
+        /// </summary>
+        /// <param name="createConfiguration">The <see cref="Func{IConfiguration}"/>.</param>
+        public Properties(Func<IConfiguration> createConfiguration)
+        {
+            this.createConfiguration = createConfiguration ?? throw new ArgumentNullException(nameof(createConfiguration));
+        }
+
+        /// <summary>
+        /// Retrieves the value of an property from the current process.
+        /// </summary>
+        /// <param name="key">The name of the property.</param>
+        /// <returns>The property value.</returns>
+        public string GetProperty(string key)
+        {
+            return GetProperty(key, null);
+        }
+
+        /// <summary>
+        /// Retrieves the value of an property from the current process, 
+        /// with a default value if it doens't exist or the caller doesn't have 
+        /// permission to read the value.
+        /// </summary>
+        /// <param name="key">The name of the property.</param>
+        /// <param name="defaultValue">The value to use if the property does not exist 
+        /// or the caller doesn't have permission to read the value.</param>
+        /// <returns>The property value.</returns>
+        public string GetProperty(string key, string defaultValue)
+        {
+            return GetProperty(key, defaultValue,
+                (str) =>
+                {
+                    return str;
+                }
+            );
+        }
+
+        /// <summary>
+        /// Retrieves the value of an property from the current process
+        /// as <see cref="bool"/>. If the value cannot be cast to <see cref="bool"/>, returns <c>false</c>.
+        /// </summary>
+        /// <param name="key">The name of the property.</param>
+        /// <returns>The property value.</returns>
+        public bool GetPropertyAsBoolean(string key)
+        {
+            return GetPropertyAsBoolean(key, false);
+        }
+
+        /// <summary>
+        /// Retrieves the value of an property from the current process as <see cref="bool"/>, 
+        /// with a default value if it doens't exist, the caller doesn't have permission to read the value, 
+        /// or the value cannot be cast to a <see cref="bool"/>.
+        /// </summary>
+        /// <param name="key">The name of the property.</param>
+        /// <param name="defaultValue">The value to use if the property does not exist,
+        /// the caller doesn't have permission to read the value, or the value cannot be cast to <see cref="bool"/>.</param>
+        /// <returns>The property value.</returns>
+        public bool GetPropertyAsBoolean(string key, bool defaultValue)
+        {
+            return GetProperty(key, defaultValue,
+                (str) =>
+                {
+                    return bool.TryParse(str, out bool value) ? value : defaultValue;
+                }
+            );
+        }
+
+        /// <summary>
+        /// Retrieves the value of an property from the current process
+        /// as <see cref="int"/>. If the value cannot be cast to <see cref="int"/>, returns <c>0</c>.
+        /// </summary>
+        /// <param name="key">The name of the property.</param>
+        /// <returns>The property value.</returns>
+        public int GetPropertyAsInt32(string key)
+        {
+            return GetPropertyAsInt32(key, 0);
+        }
+
+        /// <summary>
+        /// Retrieves the value of an property from the current process as <see cref="int"/>, 
+        /// with a default value if it doens't exist, the caller doesn't have permission to read the value, 
+        /// or the value cannot be cast to a <see cref="int"/>.
+        /// </summary>
+        /// <param name="key">The name of the property.</param>
+        /// <param name="defaultValue">The value to use if the property does not exist,
+        /// the caller doesn't have permission to read the value, or the value cannot be cast to <see cref="int"/>.</param>
+        /// <returns>The property value.</returns>
+        public int GetPropertyAsInt32(string key, int defaultValue)
+        {
+            return GetProperty(key, defaultValue,
+                (str) =>
+                {
+                    return int.TryParse(str, out int value) ? value : defaultValue;
+                }
+            );
+        }
+
+        private T GetProperty<T>(string key, T defaultValue, Func<string, T> conversionFunction)
+        {
+            IConfiguration configuration = createConfiguration();
+            string setting = configuration[key];
+
+            return string.IsNullOrEmpty(setting)
+                ? defaultValue
+                : conversionFunction(setting);
+        }
+    }
+}


### PR DESCRIPTION
This is a refactoring of the `SystemProperties` static class by converting the business logic into an instance class backed by an interface, so the business logic of converting data types and defaulting values can be unit tested using a mock `IConfiguration` instance.

## Example

```c#
    // Reusable mock configuration for tests
    internal class MockConfiguration : IConfiguration
    {
        private readonly IDictionary<string, string> configuration;

        public MockConfiguration(IDictionary<string, string> configuration)
        {
            this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
        }

        public string this[string key]
        {
            get => configuration[key];
            set => configuration[key] = value;
        }

        public IEnumerable<IConfigurationSection> GetChildren()
        {
            throw new NotImplementedException();
        }

        public IChangeToken GetReloadToken()
        {
            throw new NotImplementedException();
        }

        public IConfigurationSection GetSection(string key)
        {
            throw new NotImplementedException();
        }
    }

    [Test]
    public void TestProperty()
    {
        // Arrange
        var target = new Properties(new MockConfiguration(new Dictionary<string, string>
        {
            ["foo"] = "bar", 
            ["foo2"] = "bar2"
        }));

        // Act
        string result = target.GetProperty("foo2", "default");
        
        // Assert
        Assert.AreEqual("bar2", result);
    }
```

## Approach

1. Unit test `Properties` class, using the approach above.
2. Unit test the `Microsoft.Extensions.Configuration` derived classes in a similar way that Microsoft does.
3. Consider the operations of setting properties and reloading configuration toxic methods in tests. This is not an approach end users of the test framework can take advantage of. Perhaps we could go back to using `IConfiguration` instead of `IConfigurationRoot` to hide the toxic `Reload` method.
4. Consider static `ConfigurationSettings` and `SystemProperties` classes as *humble objects*. That is, their implementations are simply delegating calls, so there is no reason for testing them separately.
5. Consider all other Lucene.NET tests as integration tests.

There may be other things to mock out and test as well (such as the folder caching or the parent folder loading), but we should aim to do so without depending on the file system. Direct static method calls can be replaced with internal static delegate methods so those methods can be redirected to mock methods in tests.

```c#
public static void DoSomething(string filePath)
{
    if (fileExists(filePath))
    {
         // implementation...
    }
}

internal static Func<string, bool> fileExists = (filePath) => File.Exists(filePath);
```

Then, tests can simply set the fileExists delegate to a different implementation.

In a similar way, `new DirectoryInfo(path)` can be replaced with a delegate factory method for mocking.